### PR TITLE
Add Category trait to Item factory

### DIFF
--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -4,6 +4,13 @@ FactoryGirl.define do
     description 'Delicious chicken pad thai with peanuts and chilli flakes by the side.'
     price 12.5
     available true
+
+    trait :with_category do
+      after(:create) do |item|
+        category = create(:category)
+        create(:categorization, item: item, category: category)
+      end
+    end
   end
 
   factory :category do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Item, type: :model do
   it "has a valid factory" do
-    item = create(:item)
+    item = build(:item)
     expect(item.valid?).to eq true
   end
 
@@ -31,7 +31,7 @@ RSpec.describe Item, type: :model do
 
   describe "associations" do
     before do
-      @item = create(:item)
+      @item = create(:item, :with_category)
     end
 
     it "can have categories" do
@@ -39,9 +39,7 @@ RSpec.describe Item, type: :model do
     end
 
     it "return its categories" do
-      category = create(:category)
-      create(:categorization, category: category, item: @item)
-      expect(@item.categories).to eq [category]
+      expect(@item.categories).to eq [Category.first]
     end
   end
 end


### PR DESCRIPTION
## Problem: Deadlocked Validation Dependency
- An `Item` not yet created cannot allow creation of a `Categorization` (because `item_id` is nil)
- When an `item` tries to validate `categories.count` before creation, this will fail as no `Categorization` has been created

**Question**: can an `Item` have no `Category`? This can be a valid use-case. The item can be assigned one or more categories later.

---

For the item spec, it may be simpler to create an item either on its own or with a category
- creating a standalone item:
  
  ```
  item = build(:item)
  ```
- creating an item with category can make use of `traits`, as shown in this PR. Reference [here](https://robots.thoughtbot.com/remove-duplication-with-factorygirls-traits)

Later in `ItemsController#create` you can do

```
category_name = params[:item].del(:category_name)
if category_name
  category = Category.find_by_or_create(name: category_name)
  @item = category.items.build(params[:items]) # this creates a categorization and associates with both category and item
else
  @item = Item.new(params[:items])
end

if @item.save
  # success response
else
  # failure response
end
```

---

Another alternative is to implement a `find_or_create_category` method as `after_create` callback for `Item` model - this is more advanced.

```
after_create :create_or_associate_category

private
  def create_or_associate_category
    # ...
  end
```
